### PR TITLE
Adjusting the 2 channel sample's gain voltage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Whole home power monitoring and additional power circuits with ESPHome and Home 
 
 Video Demostration and Setup - https://youtu.be/BOgy6QbfeZk
 
-Update 2019/08/24 - For v1.2 of the board your voltage calibration will be high, >64,000. This is normal. 
+Update 2019/08/24 - For v1.2 of the board your voltage calibration will be high, >64,000. This is normal.
 
 ### Parts List
 [Split Core Current Transformer 100A/50ma](https://amzn.to/2JtuRSt)  
@@ -19,12 +19,15 @@ If you have any to add or changes to these, pleast let us know! These are based 
 
 [SCT-024TSL-B27 200A/100mA](https://circuitsetup.us/product/200a-100ma-current-transformer-yhdc-sct-024-24mm/) - 12597 \*(2 chan board, gain_pga = 4X)
 
+### Sample Calibrations for Gain Voltage (`gain_voltage`)
+For the 2 channel board and the 9VAC power supply:
+[SCT-013-000 100A/50ma](https://amzn.to/2JtuRSt) - 3900
+
 ### Sample ESPHome YAML Configurations
 digi_nrg_2chan32.yaml - Included in this repo   
-digi_nrg_6chan32.yaml - Included in this repo 
+digi_nrg_6chan32.yaml - Included in this repo
 Note: If you elected to add expansion boards, refer to the two physical jumpers on the top of each expansion board. They will identify each of the CS_PINs you will need to include in the 6 channel example above. You can then replicate the code and change the CS_Pin and CT identifiers.
 
 ![alt text](https://raw.githubusercontent.com/digiblur/digiNRG_ESPHome/master/jpgs/2chan_board.jpg "2 Channel")  
 ![alt text](https://raw.githubusercontent.com/digiblur/digiNRG_ESPHome/master/jpgs/6chan_board.jpg "6 Channel")  
 ![alt text](https://raw.githubusercontent.com/digiblur/digiNRG_ESPHome/master/jpgs/sct_100a.jpg "SCT")  
-

--- a/digi_nrg_2chan32.yaml
+++ b/digi_nrg_2chan32.yaml
@@ -1,5 +1,5 @@
 substitutions:
-# Change the disp_name to something you want  
+# Change the disp_name to something you want
   disp_name: 2C
 # Interval of how often the power is updated
   update_time: 10s
@@ -8,7 +8,7 @@ esphome:
   name: digi_nrg_2chan32
   platform: ESP32
   board: nodemcu-32s
-   
+
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_pass
@@ -27,7 +27,7 @@ mqtt:
 logger:
 
 #api:
-  
+
 ota:
 
 web_server:
@@ -55,8 +55,8 @@ sensor:
         name: ${disp_name} CT1 Watts
         accuracy_decimals: 1
         id: "ct1Watts"
-# Voltage using a 12VAC power transformer
-      gain_voltage: 32428
+# Voltage using a 9VAC power transformer
+      gain_voltage: 3900
 # Current calibration using a 100A/50ma SCT-013-000
       gain_ct: 24131
     phase_c:
@@ -70,7 +70,7 @@ sensor:
 # If the wattage is backwards due to the phase 180 degrees from the clamp direction
         filters:
           - multiply: -1.0
-      gain_voltage: 32428
+      gain_voltage: 3900
       gain_ct: 24131
     frequency:
       name: ${disp_name} Freq
@@ -83,7 +83,7 @@ sensor:
     lambda: return id(ct1Amps).state + id(ct2Amps).state;
     accuracy_decimals: 2
     unit_of_measurement: A
-    update_interval: ${update_time}  
+    update_interval: ${update_time}
     icon: "mdi:flash-circle"
   - platform: template
     name: ${disp_name} Total Watts
@@ -100,11 +100,11 @@ sensor:
     filters:
       - multiply: 0.001
     unit_of_measurement: kWh
-    
+
 time:
   - platform: sntp
-    id: sntp_time    
-    
+    id: sntp_time
+
 switch:
   - platform: restart
-    name: ${disp_name} Restart     
+    name: ${disp_name} Restart


### PR DESCRIPTION
Fixes #8.

The `gain_voltage`sample values are too high for the 2 channel board, 100A/50mA CTs, and split phase 240V power. This PR lowers them so the voltage reading will be close to 120V, instead of around 655V.